### PR TITLE
Add Go implementation of the ordu library

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,3 +25,21 @@ jobs:
       - run: npm install
       - run: npm run build
       - run: npm test
+
+  test-go:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        go-version: ['1.21', 'stable']
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - run: go test ./...
+        working-directory: go

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,5 @@
+module github.com/rjrodger/ordu/go
+
+go 1.21
+
+require github.com/rjrodger/nua/go v0.1.0

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,0 +1,2 @@
+github.com/rjrodger/nua/go v0.1.0 h1:Qm4SI0KsSADMrjj5mg88QlYB3n1kpZ053q5SkEfPJdA=
+github.com/rjrodger/nua/go v0.1.0/go.mod h1:FEdjEmBhLMbHBWqMjI4laiINLtY7CxqRrYunQ/uCZtg=

--- a/go/ordu.go
+++ b/go/ordu.go
@@ -1,0 +1,649 @@
+// Copyright (c) 2016-2025 Richard Rodger and other contributors, MIT License
+
+package ordu
+
+import (
+	"errors"
+	"fmt"
+	"math/rand"
+	"sort"
+	"strings"
+	"time"
+
+	nua "github.com/rjrodger/nua/go"
+)
+
+var taskCount int
+
+// TaskExec is the function signature for task execution.
+type TaskExec func(s *TaskSpec) *TaskReturn
+
+// SelectFunc is a function-based selector for child tasks.
+type SelectFunc func(source map[string]any, s *TaskSpec) any
+
+// TaskDef defines a task to add to an Ordu instance.
+type TaskDef struct {
+	ID     string
+	Name   string
+	Before string
+	After  string
+	Exec   TaskExec
+	If     map[string]any
+	Active *bool
+	Meta   map[string]any
+
+	// Select specifies a path (string) or function (SelectFunc) to select children.
+	// An empty string means root.
+	Select any
+
+	// Apply specifies child task definitions: a *TaskDef or []*TaskDef.
+	Apply any
+}
+
+// TaskReturn is returned by a TaskExec function.
+type TaskReturn struct {
+	Op  string
+	Out map[string]any
+	Err error
+	Why string
+}
+
+// TaskSpec is passed to a TaskExec function.
+type TaskSpec struct {
+	Ctx  map[string]any
+	Data map[string]any
+	Task *Task
+	Opts *Options
+	Node *Node
+}
+
+// Node represents a child element during select/apply iteration.
+type Node struct {
+	Key any
+	Val any
+}
+
+// Task is an internal representation of a task after normalization.
+type Task struct {
+	RunID  string
+	Name   string
+	Before string
+	After  string
+	Exec   TaskExec
+	If     map[string]any
+	Active bool
+	Meta   map[string]any
+}
+
+// TaskResult captures the result of executing a single task.
+type TaskResult struct {
+	Op    string
+	Out   map[string]any
+	Err   error
+	Why   string
+	Task  *Task
+	Name  string
+	Start int64
+	End   int64
+	RunID string
+	Index int
+	Total int
+}
+
+func (tr *TaskResult) update(ret *TaskReturn) {
+	if ret == nil {
+		tr.Out = map[string]any{}
+		tr.Op = "next"
+		tr.Why = ""
+		return
+	}
+
+	if ret.Out == nil {
+		tr.Out = map[string]any{}
+	} else {
+		tr.Out = ret.Out
+	}
+
+	tr.Err = ret.Err
+
+	if tr.Err != nil {
+		tr.Op = "stop"
+	} else if ret.Op != "" {
+		tr.Op = ret.Op
+	} else {
+		tr.Op = "next"
+	}
+
+	tr.Why = ret.Why
+}
+
+// Operate is the result of an operator function.
+type Operate struct {
+	Stop bool
+	Err  error
+}
+
+// Operator processes a task result and decides whether to continue.
+type Operator func(r *TaskResult, ctx map[string]any, data map[string]any) (*Operate, error)
+
+// TaskLogEntry is an entry in the execution task log.
+type TaskLogEntry struct {
+	Name    string
+	Op      string
+	Task    *Task
+	Result  *TaskResult
+	Operate *Operate
+	Data    map[string]any
+}
+
+// ExecResult is the result of executing an Ordu task list.
+type ExecResult struct {
+	TaskLog   []TaskLogEntry
+	Task      *Task
+	TaskCount int
+	TaskTotal int
+	Start     int64
+	End       int64
+	Err       error
+	Data      map[string]any
+}
+
+// Options configures an Ordu instance.
+type Options struct {
+	Debug  bool
+	Select SelectOptions
+}
+
+// SelectOptions controls child selection sorting.
+type SelectOptions struct {
+	Sort *int
+}
+
+// TaskResultHandler is called after each task result.
+type TaskResultHandler func(tr *TaskResult)
+
+// TaskEndHandler is called after each task completes.
+type TaskEndHandler func(entry *TaskLogEntry)
+
+// Ordu executes functions in a configurable order, modifying shared data.
+type Ordu struct {
+	opts        Options
+	tasks       []*Task
+	operatorMap map[string]Operator
+	Task        map[string]*Task
+
+	OnTaskResult TaskResultHandler
+	OnTaskEnd    TaskEndHandler
+}
+
+// New creates a new Ordu instance with the given options.
+func New(opts *Options) *Ordu {
+	o := &Ordu{
+		tasks:       []*Task{},
+		operatorMap: map[string]Operator{},
+		Task:        map[string]*Task{},
+	}
+
+	if opts != nil {
+		o.opts = *opts
+	}
+
+	o.operatorMap["next"] = func(r *TaskResult, ctx, data map[string]any) (*Operate, error) {
+		return &Operate{Stop: false}, nil
+	}
+
+	o.operatorMap["skip"] = func(r *TaskResult, ctx, data map[string]any) (*Operate, error) {
+		return &Operate{Stop: false}, nil
+	}
+
+	o.operatorMap["stop"] = func(r *TaskResult, ctx, data map[string]any) (*Operate, error) {
+		nua.Merge(data, r.Out, &nua.Options{Preserve: true})
+		return &Operate{Stop: true, Err: r.Err}, nil
+	}
+
+	o.operatorMap["merge"] = func(r *TaskResult, ctx, data map[string]any) (*Operate, error) {
+		nua.Merge(data, r.Out, &nua.Options{Preserve: true})
+		return &Operate{Stop: false}, nil
+	}
+
+	return o
+}
+
+// SetOperator registers a named operator.
+func (o *Ordu) SetOperator(name string, opr Operator) {
+	o.operatorMap[name] = opr
+}
+
+// Operators returns the operator map.
+func (o *Ordu) Operators() map[string]Operator {
+	return o.operatorMap
+}
+
+// Add adds one or more task definitions to the Ordu instance.
+func (o *Ordu) Add(tds ...*TaskDef) *Ordu {
+	for _, td := range tds {
+		o.addTask(td)
+	}
+	return o
+}
+
+// AddExec adds a task from a bare exec function and optional name.
+func (o *Ordu) AddExec(name string, exec TaskExec) *Ordu {
+	o.addTask(&TaskDef{Name: name, Exec: exec})
+	return o
+}
+
+// Tasks returns a copy of the task list.
+func (o *Ordu) Tasks() []*Task {
+	out := make([]*Task, len(o.tasks))
+	copy(out, o.tasks)
+	return out
+}
+
+func (o *Ordu) addTask(td *TaskDef) {
+	t := newTask(td, o)
+
+	tI := 0
+	for ; tI < len(o.tasks); tI++ {
+		if t.Before != "" && o.tasks[tI].Name == t.Before {
+			break
+		} else if t.After != "" && o.tasks[tI].Name == t.After {
+			tI++
+			break
+		}
+	}
+
+	// splice insert
+	o.tasks = append(o.tasks, nil)
+	copy(o.tasks[tI+1:], o.tasks[tI:])
+	o.tasks[tI] = t
+
+	o.Task[t.Name] = t
+}
+
+func newTask(td *TaskDef, parent *Ordu) *Task {
+	t := &Task{}
+
+	if td.ID != "" {
+		t.RunID = td.ID
+	} else {
+		t.RunID = fmt.Sprintf("%d", rand.Int63())
+	}
+
+	if td.Name != "" {
+		t.Name = td.Name
+	} else {
+		t.Name = fmt.Sprintf("task%d", taskCount)
+		taskCount++
+	}
+
+	t.Before = td.Before
+	t.After = td.After
+
+	if td.Exec != nil {
+		t.Exec = td.Exec
+	} else {
+		t.Exec = func(s *TaskSpec) *TaskReturn { return nil }
+	}
+
+	t.If = td.If
+
+	if td.Active != nil {
+		t.Active = *td.Active
+	} else {
+		t.Active = true
+	}
+
+	t.Meta = td.Meta
+	if t.Meta == nil {
+		t.Meta = map[string]any{}
+	}
+	t.Meta["when"] = time.Now().UnixMilli()
+
+	// Selection
+	if td.Select != nil {
+		setupSelect(t, td, parent)
+	}
+
+	return t
+}
+
+func setupSelect(t *Task, td *TaskDef, parent *Ordu) {
+	cordu := New(nil)
+
+	switch apply := td.Apply.(type) {
+	case *TaskDef:
+		cordu.Add(apply)
+	case []*TaskDef:
+		cordu.Add(apply...)
+	case TaskExec:
+		cordu.AddExec("", apply)
+	}
+
+	t.Exec = func(s *TaskSpec) *TaskReturn {
+		var source map[string]any
+		if s.Node != nil {
+			if m, ok := s.Node.Val.(map[string]any); ok {
+				source = m
+			}
+		}
+		if source == nil {
+			source = s.Data
+		}
+		if source == nil {
+			source = map[string]any{}
+		}
+
+		var target any
+
+		switch sel := td.Select.(type) {
+		case string:
+			if sel == "" {
+				target = source
+			} else {
+				target = reach(source, sel)
+			}
+		case SelectFunc:
+			target = sel(source, s)
+		}
+
+		type child struct {
+			key any
+			val any
+		}
+
+		var children []child
+
+		switch v := target.(type) {
+		case []any:
+			for i, n := range v {
+				children = append(children, child{key: i, val: n})
+			}
+		case map[string]any:
+			for k, n := range v {
+				children = append(children, child{key: k, val: n})
+			}
+		}
+
+		if s.Opts != nil && s.Opts.Select.Sort != nil {
+			dir := 1
+			if *s.Opts.Select.Sort < 0 {
+				dir = -1
+			}
+			sort.SliceStable(children, func(i, j int) bool {
+				ki := fmt.Sprintf("%v", children[i].key)
+				kj := fmt.Sprintf("%v", children[j].key)
+				if dir > 0 {
+					return ki < kj
+				}
+				return ki > kj
+			})
+		}
+
+		for _, c := range children {
+			node := &Node{Key: c.key, Val: c.val}
+			cres := cordu.Exec(s.Ctx, s.Data, s.Opts, node)
+			if cres.Err != nil {
+				return &TaskReturn{Err: cres.Err}
+			}
+		}
+
+		return nil
+	}
+}
+
+// Exec executes the task list synchronously.
+func (o *Ordu) Exec(ctx, data map[string]any, opts *Options, node ...*Node) *ExecResult {
+	if ctx == nil {
+		ctx = map[string]any{}
+	}
+	if data == nil {
+		data = map[string]any{}
+	}
+
+	mergedOpts := o.opts
+	if opts != nil {
+		if opts.Debug {
+			mergedOpts.Debug = true
+		}
+		if opts.Select.Sort != nil {
+			mergedOpts.Select.Sort = opts.Select.Sort
+		}
+	}
+
+	runid := fmt.Sprintf("%d", rand.Int63())
+	start := time.Now().UnixMilli()
+	tasks := make([]*Task, len(o.tasks))
+	copy(tasks, o.tasks)
+
+	var tasklog []TaskLogEntry
+	taskcount := 0
+	lastTaskI := 0
+	var lastOperate *Operate
+
+	var curNode *Node
+	if len(node) > 0 {
+		curNode = node[0]
+	}
+
+	for taskI := 0; taskI < len(tasks); {
+		lastTaskI = taskI
+		task := tasks[taskI]
+
+		result := &TaskResult{
+			Op:    "not-defined",
+			Task:  task,
+			Name:  task.Name,
+			Start: time.Now().UnixMilli(),
+			End:   0,
+			Index: taskI,
+			Total: len(tasks),
+			RunID: runid,
+		}
+
+		var ret *TaskReturn
+
+		if task.Active && o.taskIf(task, data) {
+			taskcount++
+
+			spec := &TaskSpec{
+				Ctx:  ctx,
+				Data: data,
+				Task: task,
+				Opts: &mergedOpts,
+				Node: curNode,
+			}
+
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						if err, ok := r.(error); ok {
+							ret = &TaskReturn{Err: err}
+						} else {
+							ret = &TaskReturn{Err: fmt.Errorf("%v", r)}
+						}
+					}
+				}()
+				ret = task.Exec(spec)
+			}()
+		} else {
+			ret = &TaskReturn{Op: "skip"}
+		}
+
+		result.End = time.Now().UnixMilli()
+		result.update(ret)
+
+		if o.OnTaskResult != nil {
+			o.OnTaskResult(result)
+		}
+
+		operate := &Operate{}
+		opr, oprErr := o.operate(result, ctx, data)
+		if oprErr != nil {
+			operate.Stop = true
+			operate.Err = oprErr
+		} else {
+			operate = opr
+		}
+
+		lastOperate = operate
+
+		entry := TaskLogEntry{
+			Name:    task.Name,
+			Op:      result.Op,
+			Task:    task,
+			Result:  result,
+			Operate: operate,
+		}
+		tasklog = append(tasklog, entry)
+
+		if o.OnTaskEnd != nil {
+			o.OnTaskEnd(&entry)
+		}
+
+		if operate.Stop {
+			break
+		}
+		taskI++
+	}
+
+	var finalErr error
+	if lastOperate != nil {
+		finalErr = lastOperate.Err
+	}
+
+	var errTask *Task
+	if finalErr != nil {
+		errTask = tasks[lastTaskI]
+	}
+
+	return &ExecResult{
+		TaskLog:   tasklog,
+		Task:      errTask,
+		TaskCount: taskcount,
+		TaskTotal: len(tasks),
+		Start:     start,
+		End:       time.Now().UnixMilli(),
+		Err:       finalErr,
+		Data:      data,
+	}
+}
+
+func (o *Ordu) operate(r *TaskResult, ctx, data map[string]any) (*Operate, error) {
+	if r.Err != nil {
+		return &Operate{Stop: true, Err: r.Err}, nil
+	}
+
+	operator, ok := o.operatorMap[r.Op]
+	if !ok {
+		return &Operate{Stop: true, Err: fmt.Errorf("Unknown operation: %s", r.Op)}, nil
+	}
+
+	return operator(r, ctx, data)
+}
+
+func (o *Ordu) taskIf(task *Task, data map[string]any) bool {
+	if task.If == nil {
+		return true
+	}
+
+	for k, expected := range task.If {
+		part := reach(data, k)
+		if !deepContain(part, expected) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// reach accesses a nested property via dot-separated path.
+func reach(obj map[string]any, path string) any {
+	parts := strings.Split(path, ".")
+	var current any = obj
+	for _, part := range parts {
+		if current == nil {
+			return nil
+		}
+		switch m := current.(type) {
+		case map[string]any:
+			current = m[part]
+		default:
+			return nil
+		}
+	}
+	return current
+}
+
+// deepContain checks if actual deeply contains expected.
+func deepContain(actual, expected any) bool {
+	if actual == expected {
+		return true
+	}
+
+	if expected == nil || actual == nil {
+		return false
+	}
+
+	switch exp := expected.(type) {
+	case int:
+		switch act := actual.(type) {
+		case int:
+			return act == exp
+		case float64:
+			return act == float64(exp)
+		}
+		return false
+	case float64:
+		switch act := actual.(type) {
+		case float64:
+			return act == exp
+		case int:
+			return float64(act) == exp
+		}
+		return false
+	case string:
+		act, ok := actual.(string)
+		return ok && act == exp
+	case bool:
+		act, ok := actual.(bool)
+		return ok && act == exp
+	case []any:
+		act, ok := actual.([]any)
+		if !ok {
+			return false
+		}
+		for i, v := range exp {
+			if i >= len(act) {
+				return false
+			}
+			if !deepContain(act[i], v) {
+				return false
+			}
+		}
+		return true
+	case map[string]any:
+		act, ok := actual.(map[string]any)
+		if !ok {
+			return false
+		}
+		for k, v := range exp {
+			if !deepContain(act[k], v) {
+				return false
+			}
+		}
+		return true
+	}
+
+	return errors.Is(expected.(error), actual.(error))
+}
+
+// Active returns a pointer to a bool, for use with TaskDef.Active.
+func Active(v bool) *bool {
+	return &v
+}
+
+// SortDir returns a pointer to an int, for use with SelectOptions.Sort.
+func SortDir(v int) *int {
+	return &v
+}

--- a/go/ordu_test.go
+++ b/go/ordu_test.go
@@ -1,0 +1,574 @@
+// Copyright (c) 2016-2025 Richard Rodger and other contributors, MIT License
+
+package ordu
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestSanity(t *testing.T) {
+	h0 := New(nil)
+	if h0 == nil {
+		t.Fatal("expected non-nil Ordu")
+	}
+}
+
+func TestHappy(t *testing.T) {
+	h0 := New(nil)
+
+	h0.AddExec("", func(s *TaskSpec) *TaskReturn {
+		x, _ := s.Data["x"].(int)
+		return &TaskReturn{
+			Op:  "merge",
+			Out: map[string]any{"y": x * 10},
+		}
+	})
+
+	o0 := h0.Exec(nil, map[string]any{"x": 11}, nil)
+	expectDeep(t, o0.Data, map[string]any{"x": 11, "y": 110})
+
+	o1 := h0.Exec(nil, map[string]any{"x": 22}, nil)
+	expectDeep(t, o1.Data, map[string]any{"x": 22, "y": 220})
+}
+
+func TestBasic(t *testing.T) {
+	tc := taskCount
+	h0 := New(nil)
+
+	var taskResultLog []*TaskResult
+	var taskEndLog []*TaskLogEntry
+
+	h0.OnTaskResult = func(tr *TaskResult) {
+		taskResultLog = append(taskResultLog, tr)
+	}
+	h0.OnTaskEnd = func(entry *TaskLogEntry) {
+		taskEndLog = append(taskEndLog, entry)
+	}
+
+	// Task A - no exec
+	h0.Add(&TaskDef{Name: "A"})
+
+	// Task B - inactive
+	h0.Add(&TaskDef{Name: "B", Active: Active(false)})
+
+	// Task with error handling
+	h0.AddExec("errtask", func(s *TaskSpec) *TaskReturn {
+		if s.Ctx["err0"] == true {
+			panic(errors.New("err0"))
+		}
+		if s.Ctx["err2"] == true {
+			return &TaskReturn{Op: "not-an-op"}
+		}
+		return nil
+	})
+
+	// Merge task
+	h0.Add(&TaskDef{
+		ID: "0",
+		Exec: func(s *TaskSpec) *TaskReturn {
+			return &TaskReturn{Op: "merge", Out: map[string]any{"x": 2}, Why: "some-reason"}
+		},
+	})
+
+	// Conditional task (should be skipped when x!=4 or xx!=40)
+	h0.Add(&TaskDef{
+		If: map[string]any{"x": 4, "xx": 40},
+		Exec: func(s *TaskSpec) *TaskReturn {
+			return &TaskReturn{Op: "merge", Out: map[string]any{"q": 1}}
+		},
+	})
+
+	// Task b
+	h0.Add(&TaskDef{
+		Name: "b",
+		Exec: func(s *TaskSpec) *TaskReturn {
+			return &TaskReturn{Op: "merge", Out: map[string]any{"x": 4}}
+		},
+	})
+
+	// Task c with custom operator
+	h0.Add(&TaskDef{
+		Name: "c",
+		Exec: func(s *TaskSpec) *TaskReturn {
+			return &TaskReturn{Op: "lookup", Out: map[string]any{"id": "001"}}
+		},
+	})
+
+	// Conditional task (should run when x==4)
+	h0.Add(&TaskDef{
+		If: map[string]any{"x": 4},
+		Exec: func(s *TaskSpec) *TaskReturn {
+			return &TaskReturn{Op: "merge", Out: map[string]any{"qq": 2}}
+		},
+	})
+
+	// Stop task
+	h0.Add(&TaskDef{
+		Exec: func(s *TaskSpec) *TaskReturn {
+			return &TaskReturn{Op: "stop", Out: map[string]any{"last": 99}}
+		},
+	})
+
+	// Should never be reached
+	h0.Add(&TaskDef{
+		Exec: func(s *TaskSpec) *TaskReturn {
+			return &TaskReturn{Op: "merge", Out: map[string]any{"should-never-be-reached": true}}
+		},
+	})
+
+	// Register lookup operator
+	h0.SetOperator("lookup", func(r *TaskResult, ctx, data map[string]any) (*Operate, error) {
+		if ctx["err1"] == true {
+			return nil, errors.New("err1")
+		}
+		data["y"] = r.Out
+		return &Operate{Stop: false}, nil
+	})
+
+	expectEqual(t, len(h0.Tasks()), 10)
+
+	out := h0.Exec(nil, nil, nil)
+	expectDeep(t, out.Data, map[string]any{"x": 4, "y": map[string]any{"id": "001"}, "qq": 2, "last": 99})
+	expectEqual(t, out.TaskCount, 7)
+	expectEqual(t, out.TaskTotal, 10)
+
+	// Check task result log
+	resultOps := make([]string, len(taskResultLog))
+	for i, tr := range taskResultLog {
+		resultOps[i] = tr.Name + "~" + tr.Op
+	}
+	expectDeepStr(t, resultOps, []string{
+		"A~next",
+		"B~skip",
+		"errtask~next",
+		fmt.Sprintf("task%d~merge", tc),
+		fmt.Sprintf("task%d~skip", tc+1),
+		"b~merge",
+		"c~lookup",
+		fmt.Sprintf("task%d~merge", tc+2),
+		fmt.Sprintf("task%d~stop", tc+3),
+	})
+
+	// Check task end log
+	endOps := make([]string, len(taskEndLog))
+	for i, te := range taskEndLog {
+		endOps[i] = fmt.Sprintf("%s~%s~%v", te.Name, te.Op, te.Operate.Stop)
+	}
+	expectDeepStr(t, endOps, []string{
+		"A~next~false",
+		"B~skip~false",
+		"errtask~next~false",
+		fmt.Sprintf("task%d~merge~false", tc),
+		fmt.Sprintf("task%d~skip~false", tc+1),
+		"b~merge~false",
+		"c~lookup~false",
+		fmt.Sprintf("task%d~merge~false", tc+2),
+		fmt.Sprintf("task%d~stop~true", tc+3),
+	})
+
+	// With initial data
+	out = h0.Exec(nil, map[string]any{"z": 1, "y": nil}, nil)
+	expectDeep(t, out.Data, map[string]any{"z": 1, "x": 4, "y": map[string]any{"id": "001"}, "qq": 2, "last": 99})
+
+	// Error in task
+	out = h0.Exec(map[string]any{"err0": true}, map[string]any{"z": 2}, nil)
+	expectEqual(t, out.Err.Error(), "err0")
+
+	// Operator names
+	ops := h0.Operators()
+	opNames := []string{}
+	for _, name := range []string{"next", "skip", "stop", "merge", "lookup"} {
+		if _, ok := ops[name]; ok {
+			opNames = append(opNames, name)
+		}
+	}
+	expectEqual(t, len(opNames), 5)
+
+	// Error in operator
+	out = h0.Exec(map[string]any{"err1": true}, nil, nil)
+	expectEqual(t, out.Err.Error(), "err1")
+
+	// Unknown operation
+	out = h0.Exec(map[string]any{"err2": true}, nil, nil)
+	expectEqual(t, out.Err.Error(), "Unknown operation: not-an-op")
+}
+
+func TestInsertOrder(t *testing.T) {
+	h0 := New(nil)
+	names := func() string {
+		tasks := h0.Tasks()
+		ns := make([]string, len(tasks))
+		for i, t := range tasks {
+			ns[i] = t.Name
+		}
+		return fmt.Sprintf("%s", joinStr(ns, " "))
+	}
+
+	h0.Add(&TaskDef{Name: "a"})
+	expectEqual(t, names(), "a")
+
+	h0.Add(&TaskDef{Name: "b"})
+	expectEqual(t, names(), "a b")
+
+	h0.Add(&TaskDef{Name: "c"})
+	expectEqual(t, names(), "a b c")
+
+	h0.Add(&TaskDef{Name: "A", Before: "a"})
+	expectEqual(t, names(), "A a b c")
+
+	h0.Add(&TaskDef{Name: "B", Before: "b"})
+	expectEqual(t, names(), "A a B b c")
+
+	h0.Add(&TaskDef{Name: "C", Before: "c"})
+	expectEqual(t, names(), "A a B b C c")
+
+	h0.Add(&TaskDef{Name: "a0", After: "a"})
+	expectEqual(t, names(), "A a a0 B b C c")
+
+	h0.Add(&TaskDef{Name: "b0", After: "b"})
+	expectEqual(t, names(), "A a a0 B b b0 C c")
+
+	h0.Add(&TaskDef{Name: "c0", After: "c"})
+	expectEqual(t, names(), "A a a0 B b b0 C c c0")
+
+	h0.Add(&TaskDef{Name: "A0", Before: "a"})
+	expectEqual(t, names(), "A A0 a a0 B b b0 C c c0")
+
+	h0.Add(&TaskDef{Name: "B0", Before: "b"})
+	expectEqual(t, names(), "A A0 a a0 B B0 b b0 C c c0")
+
+	h0.Add(&TaskDef{Name: "C0", Before: "c"})
+	expectEqual(t, names(), "A A0 a a0 B B0 b b0 C C0 c c0")
+
+	h0.Add(&TaskDef{Name: "a1", After: "a"})
+	expectEqual(t, names(), "A A0 a a1 a0 B B0 b b0 C C0 c c0")
+
+	h0.Add(&TaskDef{Name: "b1", After: "b"})
+	expectEqual(t, names(), "A A0 a a1 a0 B B0 b b1 b0 C C0 c c0")
+
+	h0.Add(&TaskDef{Name: "c1", After: "c"})
+	expectEqual(t, names(), "A A0 a a1 a0 B B0 b b1 b0 C C0 c c1 c0")
+
+	h0.Add(&TaskDef{Name: "A1", After: "A"})
+	expectEqual(t, names(), "A A1 A0 a a1 a0 B B0 b b1 b0 C C0 c c1 c0")
+
+	h0.Add(&TaskDef{Name: "AA0", Before: "A"})
+	expectEqual(t, names(), "AA0 A A1 A0 a a1 a0 B B0 b b1 b0 C C0 c c1 c0")
+}
+
+func TestErrors(t *testing.T) {
+	h0 := New(nil)
+
+	h0.Add(&TaskDef{
+		Name: "a",
+		Exec: func(s *TaskSpec) *TaskReturn {
+			return &TaskReturn{Err: errors.New("a-err")}
+		},
+	})
+
+	out := h0.Exec(nil, nil, nil)
+	expectEqual(t, out.Err.Error(), "a-err")
+
+	h1 := New(nil)
+	h1.Add(&TaskDef{
+		Name: "a",
+		Exec: func(s *TaskSpec) *TaskReturn {
+			panic(errors.New("a-terr"))
+		},
+	})
+
+	out = h1.Exec(nil, nil, nil)
+	expectEqual(t, out.Err.Error(), "a-terr")
+}
+
+func TestDirect(t *testing.T) {
+	h0 := New(nil)
+
+	h0.AddExec("", func(s *TaskSpec) *TaskReturn {
+		foo := s.Data["foo"].(map[string]any)
+		foo["x"] = 1
+		return nil
+	})
+
+	h0.AddExec("", func(s *TaskSpec) *TaskReturn {
+		foo := s.Data["foo"].(map[string]any)
+		foo["y"] = 2
+		return nil
+	})
+
+	foo := map[string]any{"z": 0}
+	o0 := h0.Exec(nil, map[string]any{"foo": foo}, nil)
+	expectDeep(t, foo, map[string]any{"z": 0, "x": 1, "y": 2})
+	expectDeep(t, o0.Data["foo"].(map[string]any), map[string]any{"z": 0, "x": 1, "y": 2})
+}
+
+func TestEdges(t *testing.T) {
+	h0 := New(nil)
+
+	o0 := h0.Exec(nil, nil, nil)
+	expectEqual(t, len(o0.TaskLog), 0)
+	expectEqual(t, o0.TaskCount, 0)
+	expectEqual(t, o0.TaskTotal, 0)
+
+	h0.SetOperator("foo", func(r *TaskResult, ctx, data map[string]any) (*Operate, error) {
+		return nil, errors.New("foo")
+	})
+	h0.AddExec("", func(s *TaskSpec) *TaskReturn {
+		return &TaskReturn{Op: "foo"}
+	})
+	o1 := h0.Exec(nil, nil, nil)
+	expectEqual(t, o1.Err.Error(), "foo")
+}
+
+func TestDeepSync(t *testing.T) {
+	r0 := New(nil)
+
+	f0 := func(s *TaskSpec) *TaskReturn {
+		s.Data["f0"] = 0
+		return nil
+	}
+
+	f1 := func(s *TaskSpec) *TaskReturn {
+		s.Data["f1"] = 1
+		return nil
+	}
+
+	g0 := func(s *TaskSpec) *TaskReturn {
+		v := s.Node.Val.(map[string]any)
+		g := s.Data["g"].([]any)
+		s.Data["g"] = append(g, v["x"])
+		return nil
+	}
+
+	g1 := func(s *TaskSpec) *TaskReturn {
+		v := s.Node.Val.(map[string]any)
+		g := s.Data["g"].([]any)
+		x, _ := v["x"].(int)
+		s.Data["g"] = append(g, x*2)
+		return nil
+	}
+
+	r0.Add(
+		&TaskDef{Name: "f0", Exec: f0},
+		&TaskDef{
+			Name:   "select-list0",
+			Select: "list0",
+			Apply: []*TaskDef{
+				{Name: "g0", Exec: g0},
+				{Name: "g1", Exec: g1},
+			},
+		},
+		&TaskDef{Name: "f1", Exec: f1},
+	)
+
+	d0 := map[string]any{
+		"list0": []any{
+			map[string]any{"x": 0},
+			map[string]any{"x": 1},
+		},
+		"g": []any{},
+	}
+
+	o0 := r0.Exec(nil, d0, nil)
+
+	expectDeep(t, o0.Data["g"], []any{0, 0, 1, 2})
+	expectEqual(t, o0.Data["f0"], 0)
+	expectEqual(t, o0.Data["f1"], 1)
+}
+
+func TestDeepLevels(t *testing.T) {
+	r0 := New(nil)
+
+	collect := func(s *TaskSpec) *TaskReturn {
+		v := s.Node.Val.(map[string]any)
+		n := s.Data["n"].([]any)
+		s.Data["n"] = append(n, v["n"])
+		return nil
+	}
+
+	r0.Add(&TaskDef{
+		Name:   "outer",
+		Select: "x",
+		Apply: []*TaskDef{
+			{
+				Name:   "inner",
+				Select: "",
+				Apply:  []*TaskDef{{Name: "collect", Exec: collect}},
+			},
+		},
+	})
+
+	d0 := map[string]any{
+		"x": map[string]any{
+			"x0": map[string]any{
+				"y0": map[string]any{"n": 0},
+				"y1": map[string]any{"n": 1},
+			},
+			"x1": map[string]any{
+				"y0": map[string]any{"n": 2},
+				"y1": map[string]any{"n": 3},
+			},
+		},
+		"n": []any{},
+	}
+
+	o0 := r0.Exec(nil, d0, nil)
+	n := o0.Data["n"].([]any)
+	expectEqual(t, len(n), 4)
+}
+
+func TestDeepCustom(t *testing.T) {
+	r0 := New(nil)
+
+	collect := func(s *TaskSpec) *TaskReturn {
+		v := s.Node.Val.(map[string]any)
+		n := s.Data["n"].([]any)
+		s.Data["n"] = append(n, v["n"])
+		return nil
+	}
+
+	r0.Add(&TaskDef{
+		Name: "custom",
+		Select: SelectFunc(func(source map[string]any, s *TaskSpec) any {
+			x := source["x"].(map[string]any)
+			return x["x1"]
+		}),
+		Apply: []*TaskDef{{Name: "collect", Exec: collect}},
+	})
+
+	d0 := map[string]any{
+		"x": map[string]any{
+			"x0": map[string]any{
+				"y0": map[string]any{"n": 0},
+				"y1": map[string]any{"n": 1},
+			},
+			"x1": map[string]any{
+				"y0": map[string]any{"n": 2},
+				"y1": map[string]any{"n": 3},
+			},
+		},
+		"n": []any{},
+	}
+
+	o0 := r0.Exec(nil, d0, nil)
+	n := o0.Data["n"].([]any)
+	expectEqual(t, len(n), 2)
+}
+
+func TestDeepSort(t *testing.T) {
+	sortDir := 1
+	r0 := New(&Options{
+		Select: SelectOptions{Sort: &sortDir},
+	})
+
+	g0 := func(s *TaskSpec) *TaskReturn {
+		v := s.Node.Val.(map[string]any)
+		g := s.Data["g"].([]any)
+		s.Data["g"] = append(g, v["x"])
+		return nil
+	}
+
+	g1 := func(s *TaskSpec) *TaskReturn {
+		v := s.Node.Val.(map[string]any)
+		g := s.Data["g"].([]any)
+		x, _ := v["x"].(int)
+		s.Data["g"] = append(g, x*2)
+		return nil
+	}
+
+	r0.Add(
+		&TaskDef{Name: "f0", Exec: func(s *TaskSpec) *TaskReturn {
+			s.Data["f0"] = 0
+			return nil
+		}},
+		&TaskDef{
+			Name:   "select-map0",
+			Select: "map0",
+			Apply: []*TaskDef{
+				{Name: "g0", Exec: g0},
+				{Name: "g1", Exec: g1},
+			},
+		},
+		&TaskDef{Name: "f1", Exec: func(s *TaskSpec) *TaskReturn {
+			s.Data["f1"] = 1
+			return nil
+		}},
+	)
+
+	d0 := map[string]any{
+		"map0": map[string]any{
+			"b": map[string]any{"x": 1},
+			"a": map[string]any{"x": 0},
+		},
+		"g": []any{},
+	}
+
+	o0 := r0.Exec(nil, d0, nil)
+
+	expectDeep(t, o0.Data["g"], []any{0, 0, 1, 2})
+	expectEqual(t, o0.Data["f0"], 0)
+	expectEqual(t, o0.Data["f1"], 1)
+}
+
+func TestErrorCapture(t *testing.T) {
+	r0 := New(nil)
+
+	r0.Add(
+		&TaskDef{Name: "f0", Exec: func(s *TaskSpec) *TaskReturn {
+			s.Data["f0"] = 0
+			return nil
+		}},
+		&TaskDef{Name: "f1", Exec: func(s *TaskSpec) *TaskReturn {
+			panic(errors.New("f1"))
+		}},
+		&TaskDef{Name: "f2", Exec: func(s *TaskSpec) *TaskReturn {
+			s.Data["f2"] = 1
+			return nil
+		}},
+	)
+
+	o0 := r0.Exec(nil, map[string]any{}, nil)
+	expectEqual(t, o0.Err.Error(), "f1")
+}
+
+// Test helpers
+
+func expectEqual(t *testing.T, got, want any) {
+	t.Helper()
+	if fmt.Sprintf("%v", got) != fmt.Sprintf("%v", want) {
+		t.Errorf("expected %v, got %v", want, got)
+	}
+}
+
+func expectDeep(t *testing.T, got, want any) {
+	t.Helper()
+	if fmt.Sprintf("%v", got) != fmt.Sprintf("%v", want) {
+		t.Errorf("expected %v, got %v", want, got)
+	}
+}
+
+func expectDeepStr(t *testing.T, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Errorf("length mismatch: expected %d, got %d\nexpected: %v\ngot:      %v", len(want), len(got), want, got)
+		return
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("index %d: expected %q, got %q", i, want[i], got[i])
+		}
+	}
+}
+
+func joinStr(ss []string, sep string) string {
+	result := ""
+	for i, s := range ss {
+		if i > 0 {
+			result += sep
+		}
+		result += s
+	}
+	return result
+}


### PR DESCRIPTION
Port core Ordu functionality to Go: task ordering (before/after), operators (next/skip/stop/merge), conditional execution (if), select/apply for child iteration, and event callbacks. Uses github.com/rjrodger/nua/go for the merge operator. Includes comprehensive tests mirroring the TypeScript test suite.

Also adds Go test job to the CI workflow.

https://claude.ai/code/session_01LTyoh2c5yPYmsUTy7CAcwb